### PR TITLE
Bug: Lua can generate wrong code when _ENV is <const>

### DIFF
--- a/lib/civetweb/src/third_party/lua-5.3.6/src/lparser.c
+++ b/lib/civetweb/src/third_party/lua-5.3.6/src/lparser.c
@@ -300,6 +300,7 @@ static void singlevar (LexState *ls, expdesc *var) {
     expdesc key;
     singlevaraux(fs, ls->envn, var, 1);  /* get environment variable */
     lua_assert(var->k != VVOID);  /* this one must exist */
+    luaK_exp2anyregup(fs, var);  /* but could be a constant */
     codestring(ls, &key, varname);  /* key is variable name */
     luaK_indexed(fs, var, &key);  /* env[varname] */
   }


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in lib/civetweb/src/third_party/lua-5.3.6/src/lparser.c which was cloned from lua/lua but did not receive the security patch applied in lua/lua. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/cve-2022-28805.

### Proposed Fix
Apply the same patch as the one in lua/lua to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/cve-2022-28805
https://github.com/lua/lua/commit/1f3c6f4534c6411313361697d98d1145a1f030fa